### PR TITLE
Cace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ test_upload:
 	python3 -m twine upload -u __token__ --repository testpypi dist/*
 
 upload:
-	python3 -m twine upload -u wulffern --repository pypi dist/*
+	python3 -m twine upload -u __token__ --repository pypi dist/*

--- a/cicsim/cicsim.py
+++ b/cicsim/cicsim.py
@@ -59,17 +59,16 @@ def cli():
 @cli.command()
 @click.argument("testbench")
 @click.argument("corner",nargs=-1)
-@click.option("--oformat",default="spectre",help="spectre|aimspice")
 @click.option("--run/--no-run", default=True, help="Run simulator")
 @click.option("--count", default=1, help="Run each corner count times, useful for Monte-Carlo")
 @click.option("--name", default=None, help="Control name of run file")
-@click.option("--ignore/--no-ignore", default=False,is_flag=True, help="Ignore error check")
+@click.option("--ignore/--no-ignore", default=False,is_flag=True, help="Ignore error checks")
 @click.option("--sha/--no-sha", default=False, help="Check SHA of input files")
 @click.option("--replace",default=None, help="YAML file with replacements for netlist")
-def run(testbench,oformat,run,corner,count,name,ignore,sha,replace):
+def run(testbench,run,corner,count,name,ignore,sha,replace):
     """Run a ngspice simulation of TESTBENCH
     """
-    r = cs.CmdRunNg(testbench,oformat,run,corner,name,count,sha)
+    r = cs.CmdRunNg(testbench,run,corner,name,count,sha)
     r.loadReplacements(replace)
 
     r.run(ignore)

--- a/cicsim/cicsim.py
+++ b/cicsim/cicsim.py
@@ -65,10 +65,13 @@ def cli():
 @click.option("--name", default=None, help="Control name of run file")
 @click.option("--ignore/--no-ignore", default=False,is_flag=True, help="Ignore error check")
 @click.option("--sha/--no-sha", default=False, help="Check SHA of input files")
-def run(testbench,oformat,run,corner,count,name,ignore,sha):
+@click.option("--replace",default=None, help="YAML file with replacements for netlist")
+def run(testbench,oformat,run,corner,count,name,ignore,sha,replace):
     """Run a ngspice simulation of TESTBENCH
     """
     r = cs.CmdRunNg(testbench,oformat,run,corner,name,count,sha)
+    r.loadReplacements(replace)
+
     r.run(ignore)
 
 @cli.command()

--- a/cicsim/cmdrunng.py
+++ b/cicsim/cmdrunng.py
@@ -431,8 +431,19 @@ class Simulation(cs.CdsConfig):
 
         if(len(m) > 0):
             for mg in m:
-                self.comment("Replacing  {cic%s} = %s" %(mg,self.__dict__[mg]))
+                self.comment("Replacing {cic%s} = %s" %(mg,self.__dict__[mg]))
                 line = line.replace("{cic%s}" %mg,str(self.__dict__[mg]))
+
+        #- Eval expressions
+        m = re.findall("\s+\[([^\]]+)\]",line)
+        for mg in m:
+            self.comment("Evaluating %s"%mg)
+            eresult = str(eval(mg))
+            self.comment("Replacing  [%s] = %s" %(mg,eresult))
+            line = line.replace("[%s]" %mg,eresult)
+
+
+
 
         return line
 

--- a/cicsim/cmdrunng.py
+++ b/cicsim/cmdrunng.py
@@ -454,12 +454,11 @@ class CmdRunNg(cs.CdsConfig):
     """ Run ngspice
     """
 
-    def __init__(self,testbench,oformat,runsim,corners,cornername,count,sha):
+    def __init__(self,testbench,runsim,corners,cornername,count,sha):
         self.testbench = testbench
 
 
         self.count = count
-        self.oformat = oformat
         self.runsim = runsim
         self.corners = corners
         self.cornername = cornername

--- a/cicsim/cmdrunng.py
+++ b/cicsim/cmdrunng.py
@@ -484,7 +484,7 @@ class CmdRunNg(cs.CdsConfig):
         self.filename = self.testbench + ".spi"
 
         if(not os.path.exists(self.filename)):
-            self.error(f"Testbench {self.testbench}.(spi|spice|cir) does not exists in this folder")
+            self.error(f"Testbench {self.testbench}.spi does not exists in this folder")
             return
 
         permutations = self.getPermutations(self.corners)

--- a/cicsim/cmdrunng.py
+++ b/cicsim/cmdrunng.py
@@ -63,10 +63,13 @@ class Simulation(cs.CdsConfig):
         self.keys = "|".join(list(self.__dict__.keys()))
         self.config = config
         self.replace = None
+        self.replace_re = None
 
         super().__init__()
 
     def loadReplace(self,replace):
+        if(replace is None):
+            return
         self.replace = replace
         self.replace_re = "{(%s)}" %("|".join(self.replace.keys()))
 
@@ -469,6 +472,9 @@ class CmdRunNg(cs.CdsConfig):
             exit(1)
 
     def loadReplacements(self,freplace):
+
+        if(freplace is None):
+            return
 
         if(not os.path.exists(freplace)):
             raise(Exception(f"Could not find replacement file {freplace}"))

--- a/cicsim/plot.py
+++ b/cicsim/plot.py
@@ -14,7 +14,7 @@ def plot(df,xname,yname,ptype=None,ax=None,label=""):
     if(xname not in df.columns):
         raise Exception("Could not find name %s in %s" %(xname,",".join(df.columns)))
     if(yname not in df.columns):
-        raise Exception("Could not find name %s in %s" %(xname,",".join(df.columns)))
+        raise Exception("Could not find name %s in %s" %(yname,",".join(df.columns)))
 
     x = df[xname]
     y = df[yname]
@@ -40,7 +40,10 @@ def plot(df,xname,yname,ptype=None,ax=None,label=""):
 
 
 def rawplot(fraw,xname,yname,ptype=None,axes=None):
+
+    fname = fraw
     dfs = toDataFrames(ngRawRead(fraw))
+
 
     if(len(dfs)> 0):
         df = dfs[0]
@@ -58,15 +61,15 @@ def rawplot(fraw,xname,yname,ptype=None,axes=None):
 
         for i in range(0,len(names)):
             if("same" in ptype):
-                return plot(xname,names[i],ptype,ax=axes)
+                plot(xname,names[i],ptype,ax=axes)
             else:
-                return plot(df,xname,names[i],ptype,ax=axes[i])
+                plot(df,xname,names[i],ptype,ax=axes[i])
         plt.xlabel(xname + "(" + fname + ")")
     elif(axes is not None):
-        return plot(df,xname,yname,ptype,axes,label=" %s" %fraw)
+        plot(df,xname,yname,ptype,axes,label=" %s" %fraw)
     else:
         f,axes = plt.subplots(1,1)
-        return plot(df,xname,yname,ptype,axes,label=" %s" %fraw)
+        plot(df,xname,yname,ptype,axes,label=" %s" %fraw)
 
 
 


### PR DESCRIPTION
closes #20 
closes #19 


# Added support for --replace <yaml> 

for example
replace.yaml
```yaml
t_end : 1e-3
```

testbench.spi
```
tran 1n {t_end}
```
is replaced with

output_testbench/testbench.spi
```
tran 1n 1e-3
```

# Added support for expressions

Any valid python expression (using eval()) is OK (Danger Will Robinson!)

For example:
testbench.spi
```
tran 1n [ 1/2*{t_end}]
```
output_testbench/testbench.spi
```
tran 1n 0.5e-3
```

