### PR TITLE
Overhaul wave viewer

### DIFF
--- a/cicsim/cmdwave.py
+++ b/cicsim/cmdwave.py
@@ -2,6 +2,8 @@
 
 import cicsim as cs
 import tkinter
+from tkinter import *
+from tkinter import ttk
 import os
 
 from .wavebrowser import *
@@ -20,37 +22,192 @@ from .wavegraph import *
 
 
 class CmdWave(cs.Command):
-    def __init__(self,xaxis):
+    def __init__(self, xaxis):
         super().__init__()
 
-        root = tkinter.Tk()
-        root.wm_title(f"cIcWave: {os.getcwd()}")
+        self.root = tkinter.Tk()
+        self.root.wm_title(f"cIcWave: {os.getcwd()}")
+        self.root.option_add('*tearOff', FALSE)
+        self.root.geometry("1200x700")
 
-        root.option_add('*tearOff', FALSE)
+        # --- Menu bar ---
+        menubar = Menu(self.root)
+        self.root['menu'] = menubar
 
-        #- Setup Menu
-        menubar = Menu(root)
-        root['menu'] = menubar
         menu_file = Menu(menubar)
         menu_edit = Menu(menubar)
-        menubar.add_cascade(menu=menu_file,label="File")
-        menubar.add_cascade(menu=menu_edit,label="Edit")
-        menu_file.add_command(label="New Plot",command=self.newPlot)
-        menu_file.add_command(label="Reload Plots",command=self.reloadPlots)
-        menu_file.add_command(label="Open Raw",command=self.openFileDialog)
+        menu_view = Menu(menubar)
+        menubar.add_cascade(menu=menu_file, label="File")
+        menubar.add_cascade(menu=menu_edit, label="Edit")
+        menubar.add_cascade(menu=menu_view, label="View")
 
-        #- Setup top interface
-        content = ttk.PanedWindow(root,orient=HORIZONTAL)
-        height = 500
-        self.graph = WaveGraph(content,height=height)
-        self.browser = WaveBrowser(content,self.graph,xaxis,height=height)
-        content.grid(column=0,row=0,sticky=(N,S,E,W))
+        menu_file.add_command(label="Open Raw          Ctrl+O",
+                              command=self.openFileDialog)
+        menu_file.add_command(label="Export PDF        Ctrl+P",
+                              command=self._exportPdf)
+        menu_file.add_separator()
+        menu_file.add_command(label="Quit              Ctrl+Q",
+                              command=self.root.destroy)
+
+        menu_edit.add_command(label="New Plot          Ctrl+N",
+                              command=self.newPlot)
+        menu_edit.add_command(label="Add Axis          Ctrl+A",
+                              command=self._addAxis)
+        menu_edit.add_separator()
+        menu_edit.add_command(label="Reload All        R",
+                              command=self.reloadPlots)
+        menu_edit.add_command(label="Auto Scale        F",
+                              command=self._autoSize)
+        menu_edit.add_separator()
+        menu_edit.add_command(label="Remove Selected   Delete",
+                              command=self._removeLine)
+        menu_edit.add_command(label="Remove All",
+                              command=self._removeAll)
+
+        menu_view.add_command(label="Set Cursor A      A",
+                              command=self._setCursorA)
+        menu_view.add_command(label="Set Cursor B      B",
+                              command=self._setCursorB)
+        menu_view.add_command(label="Clear Cursors     Escape",
+                              command=self._clearCursors)
+        menu_view.add_separator()
+        menu_view.add_command(label="Toggle Legend      L",
+                              command=self._toggleLegend)
+
+        menu_help = Menu(menubar)
+        menubar.add_cascade(menu=menu_help, label="Help")
+        menu_help.add_command(label="Keyboard Shortcuts",
+                              command=self._showHotkeyHelp)
+
+        # --- Main layout ---
+        content = ttk.PanedWindow(self.root, orient=HORIZONTAL)
+        height = 600
+        self.graph = WaveGraph(content, height=height)
+        self.browser = WaveBrowser(content, self.graph, xaxis, height=height)
+        content.grid(column=0, row=0, sticky=(N, S, E, W))
         content.add(self.browser)
         content.add(self.graph)
-        root.columnconfigure(0, weight=1)
-        root.rowconfigure(0, weight=1)
+        self.root.columnconfigure(0, weight=1)
+        self.root.rowconfigure(0, weight=1)
 
-        pass
+        # --- Keyboard shortcuts ---
+        self.root.bind('<Control-o>', lambda e: self.openFileDialog())
+        self.root.bind('<Control-n>', lambda e: self.newPlot())
+        self.root.bind('<Control-q>', lambda e: self.root.destroy())
+        self.root.bind('<Control-a>', lambda e: self._addAxis())
+        self.root.bind('<Control-p>', lambda e: self._exportPdf())
+        self.root.bind('<Delete>', lambda e: self._removeLine())
+        self.root.bind('<Escape>', lambda e: self._clearCursors())
+
+        # Single-key shortcuts — skip when focus is in an Entry widget
+        for key, func in [('r', self.reloadPlots),
+                          ('f', self._autoSize),
+                          ('a', self._setCursorA),
+                          ('b', self._setCursorB),
+                          ('l', self._toggleLegend)]:
+            self.root.bind(key, self._make_key_handler(func))
+
+    def _make_key_handler(self, func):
+        def handler(event):
+            if isinstance(event.widget, (ttk.Entry, Entry)):
+                return
+            func()
+        return handler
+
+    # --- Delegate to current plot tab ---
+
+    def _addAxis(self):
+        p = self.graph.getCurrentPlot()
+        if p:
+            p.addAxis()
+
+    def _autoSize(self):
+        p = self.graph.getCurrentPlot()
+        if p:
+            p.autoSize()
+
+    def _removeLine(self):
+        p = self.graph.getCurrentPlot()
+        if p:
+            p.removeLine()
+
+    def _removeAll(self):
+        p = self.graph.getCurrentPlot()
+        if p:
+            p.removeAll()
+
+    def _setCursorA(self):
+        p = self.graph.getCurrentPlot()
+        if p:
+            p.placeCursorA()
+
+    def _setCursorB(self):
+        p = self.graph.getCurrentPlot()
+        if p:
+            p.placeCursorB()
+
+    def _clearCursors(self):
+        p = self.graph.getCurrentPlot()
+        if p:
+            p.clearCursors()
+
+    def _toggleLegend(self):
+        p = self.graph.getCurrentPlot()
+        if p:
+            p.toggleLegend()
+
+    def _exportPdf(self):
+        p = self.graph.getCurrentPlot()
+        if p:
+            p.exportPdf()
+
+    def _showHotkeyHelp(self):
+        text = (
+            "Keyboard Shortcuts\n"
+            "══════════════════════════════\n"
+            "\n"
+            "File\n"
+            "  Ctrl+O        Open raw file\n"
+            "  Ctrl+P        Export PDF\n"
+            "  Ctrl+Q        Quit\n"
+            "\n"
+            "Edit\n"
+            "  Ctrl+N        New plot tab\n"
+            "  Ctrl+A        Add axis\n"
+            "  R             Reload all waves\n"
+            "  F             Auto scale (fit)\n"
+            "  Delete        Remove selected wave\n"
+            "\n"
+            "Cursors\n"
+            "  A             Set cursor A at mouse\n"
+            "  B             Set cursor B at mouse\n"
+            "  Escape        Clear cursors\n"
+            "  Click         Place cursor A\n"
+            "  Shift+Click   Place cursor B\n"
+            "  Right-Click   Place cursor B\n"
+            "  Drag cursor   Move cursor\n"
+            "\n"
+            "View\n"
+            "  L             Toggle legend\n"
+            "\n"
+            "Zoom\n"
+            "  Scroll        Zoom x-axis\n"
+            "  Shift+Scroll  Zoom y-axis\n"
+        )
+        win = Toplevel(self.root)
+        win.title("Keyboard Shortcuts")
+        win.resizable(False, False)
+        label = Label(win, text=text, justify=LEFT,
+                      font=("Courier", 11),
+                      bg="#2b2b2b", fg="#e0e0e0",
+                      padx=16, pady=12)
+        label.pack(fill=BOTH, expand=True)
+        btn = ttk.Button(win, text="Close", command=win.destroy)
+        btn.pack(pady=(0, 10))
+        win.transient(self.root)
+        win.grab_set()
+
+    # --- Menu actions ---
 
     def newPlot(self):
         self.graph.addPlot()
@@ -58,7 +215,7 @@ class CmdWave(cs.Command):
     def reloadPlots(self):
         self.graph.reloadPlots()
 
-    def openFile(self,fname):
+    def openFile(self, fname):
         self.browser.openFile(fname)
 
     def run(self):
@@ -66,5 +223,5 @@ class CmdWave(cs.Command):
 
     def openFileDialog(self):
         filename = tkinter.filedialog.askopenfilename(initialdir=os.getcwd())
-        self.browser.openFile(filename)
-        pass
+        if filename:
+            self.browser.openFile(filename)

--- a/cicsim/wavebrowser.py
+++ b/cicsim/wavebrowser.py
@@ -36,6 +36,11 @@ Click on a wave will ask the WaveGraph to show the plot
         self.tr_search = ttk.Entry(p, textvariable=self.search)
         self.search.trace_add("write", self.updateSearch)
 
+        self._tooltip = None
+        self._tooltip_id = None
+        self.tr_search.bind('<Enter>', self._show_tooltip)
+        self.tr_search.bind('<Leave>', self._hide_tooltip)
+
         self.tr_waves= ttk.Treeview(p)
         self.tr_waves.bind('<<TreeviewSelect>>', self.waveSelected)
 
@@ -45,6 +50,47 @@ Click on a wave will ask the WaveGraph to show the plot
 
         self.files = WaveFiles()
 
+
+    _REGEX_HELP = (
+        "Regex search filter\n"
+        "─────────────────────\n"
+        ".        any character\n"
+        ".*       match anything\n"
+        "^abc     starts with abc\n"
+        "abc$     ends with abc\n"
+        "[abc]    a, b, or c\n"
+        "[^abc]   not a, b, or c\n"
+        "a|b      a or b\n"
+        "\\(       literal (\n"
+        "\\d       any digit\n"
+        "Examples:\n"
+        "  v\\(.*out   signals matching v(...out\n"
+        "  ^i\\(       current signals\n"
+        "  vdd|vss    vdd or vss"
+    )
+
+    def _show_tooltip(self, event):
+        self._tooltip_id = self.tr_search.after(500, self._create_tooltip)
+
+    def _hide_tooltip(self, event=None):
+        if self._tooltip_id:
+            self.tr_search.after_cancel(self._tooltip_id)
+            self._tooltip_id = None
+        if self._tooltip:
+            self._tooltip.destroy()
+            self._tooltip = None
+
+    def _create_tooltip(self):
+        x = self.tr_search.winfo_rootx() + 20
+        y = self.tr_search.winfo_rooty() + self.tr_search.winfo_height() + 4
+        self._tooltip = Toplevel(self.tr_search)
+        self._tooltip.wm_overrideredirect(True)
+        self._tooltip.wm_geometry("+%d+%d" % (x, y))
+        label = Label(self._tooltip, text=self._REGEX_HELP,
+                      justify=LEFT, font=("Courier", 10),
+                      bg="#2b2b2b", fg="#e0e0e0",
+                      borderwidth=1, relief="solid", padx=6, pady=4)
+        label.pack()
 
     def updateSearch(self,*args):
         self.fillColumns()

--- a/cicsim/wavefiles.py
+++ b/cicsim/wavefiles.py
@@ -3,6 +3,7 @@
 import cicsim as cs
 import os
 import numpy as np
+from matplotlib.ticker import EngFormatter
 
 #- Model for wavefiles
 
@@ -18,9 +19,20 @@ class Wave():
         self.ylabel = key + f" ({wfile.name})"
         self.logx = False
         self.logy = False
+        self.xunit = ""
+        self.yunit = self._infer_yunit(key)
         self.tag = wfile.getTag(self.key)
         self.line = None
         self.reload()
+
+    @staticmethod
+    def _infer_yunit(key):
+        kl = key.lower()
+        if kl.startswith("v(") or kl.startswith("v-"):
+            return "V"
+        if kl.startswith("i(") or kl.startswith("i-"):
+            return "A"
+        return ""
 
     def deleteLine(self):
         if(self.line):
@@ -40,7 +52,10 @@ class Wave():
         else:
             self.line, = ax.plot(self.y,label=self.ylabel)
 
-        #ax.set_xlabel(self.xlabel)
+        if self.xunit:
+            ax.xaxis.set_major_formatter(EngFormatter(unit=self.xunit))
+        if self.yunit:
+            ax.yaxis.set_major_formatter(EngFormatter(unit=self.yunit))
 
     def reload(self):
         self.wfile.reload()
@@ -49,28 +64,34 @@ class Wave():
 
         if("time" in keys):
             self.x = self.wfile.df["time"].to_numpy()
-            self.xlabel = "Time [s]"
+            self.xlabel = "Time"
+            self.xunit = "s"
             self.y = self.wfile.df[self.key].to_numpy()
         elif("frequency" in keys):
             self.x = self.wfile.df["frequency"].to_numpy()
-            self.xlabel = "Frequency [Hz]"
+            self.xlabel = "Frequency"
+            self.xunit = "Hz"
             self.logx = True
             self.y = self.wfile.df[self.key].to_numpy()
         elif("v(v-sweep)" in keys):
             self.x = self.wfile.df["v(v-sweep)"].to_numpy()
-            self.xlabel = "Voltage [V]"
+            self.xlabel = "Voltage"
+            self.xunit = "V"
             self.y = self.wfile.df[self.key].to_numpy()
         elif("i(i-sweep)" in keys):
             self.x = self.wfile.df["i(i-sweep)"].to_numpy()
-            self.xlabel = "Current [I]"
+            self.xlabel = "Current"
+            self.xunit = "A"
             self.y = self.wfile.df[self.key].to_numpy()
         elif("temp-sweep" in keys):
             self.x = self.wfile.df["temp-sweep"].to_numpy()
-            self.xlabel = "Temperature [C]"
+            self.xlabel = "Temperature"
+            self.xunit = "°C"
             self.y = self.wfile.df[self.key].to_numpy()
         elif(self.xaxis in keys):
             self.x = self.wfile.df[self.xaxis].to_numpy()
             self.xlabel = " "
+            self.xunit = ""
             self.y = self.wfile.df[self.key].to_numpy()
 
         if(self.line):

--- a/cicsim/wavegraph.py
+++ b/cicsim/wavegraph.py
@@ -1,205 +1,522 @@
 #!/usr/bin/env python3
 
-#- Viewer for waves
-
 from tkinter import *
 from tkinter import ttk
 import tkinter
-from matplotlib.backend_bases import key_press_handler
+import tkinter.filedialog
+import os
+import numpy as np
 from matplotlib.backends.backend_tkagg import (FigureCanvasTkAgg,
                                                NavigationToolbar2Tk)
 from matplotlib.figure import Figure
+from matplotlib.ticker import EngFormatter
+
+CURSOR_A_COLOR = '#2196F3'
+CURSOR_B_COLOR = '#FF9800'
+CURSOR_KWARGS = {'linestyle': '--', 'linewidth': 1.0, 'alpha': 0.8}
+DRAG_TOLERANCE_PX = 10
+ZOOM_FACTOR = 1.3
 
 
 class WavePlot(ttk.PanedWindow):
-    def __init__(self,master,**kw):
-        #self.current = ttk.Frame(self.nb)
-        #self.nb.add(self.current,text="Plot")
-        super().__init__(master,orient=HORIZONTAL,**kw)
 
-        frm = ttk.Frame(self)
-        self.add(frm)
+    def __init__(self, master, **kw):
+        super().__init__(master, orient=HORIZONTAL, **kw)
 
-        self.combo = ttk.Combobox(frm)
-        self.combo.grid(column=0,row=0,columnspan=2,sticky=(N,E,W))
+        # --- Left panel: wave list and controls ---
+        left = ttk.Frame(self)
+        self.add(left)
+
+        self.combo = ttk.Combobox(left)
+        self.combo.grid(column=0, row=0, columnspan=2, sticky=(N, E, W))
         self.combo.state(["readonly"])
-        self.combo.bind('<<ComboboxSelected>>', self.setAxesIndex)
+        self.combo.bind('<<ComboboxSelected>>', self._set_axis_index)
 
-        self.tree = ttk.Treeview(frm)
-        self.tree.grid(column=0,row=1,columnspan=2,sticky=(N,S,E,W))
+        self.tree = ttk.Treeview(left)
+        self.tree.grid(column=0, row=1, columnspan=2, sticky=(N, S, E, W))
 
-        breloadAll = ttk.Button(frm,text="Reload",command=self.reloadAll)
-        breloadAll.grid(column=0,row=3,sticky=(S,E,W))
+        ttk.Button(left, text="Remove", command=self.removeLine).grid(
+            column=0, row=2, sticky=(S, E, W))
+        ttk.Button(left, text="Remove All", command=self.removeAll).grid(
+            column=1, row=2, sticky=(S, E, W))
+        ttk.Button(left, text="Reload", command=self.reloadAll).grid(
+            column=0, row=3, sticky=(S, E, W))
+        ttk.Button(left, text="Auto Scale", command=self.autoSize).grid(
+            column=1, row=3, sticky=(S, E, W))
+        ttk.Button(left, text="Add Axis", command=self.addAxis).grid(
+            column=0, row=4, sticky=(S, E, W))
+        ttk.Button(left, text="Rm Axis", command=self.removeAxis).grid(
+            column=1, row=4, sticky=(S, E, W))
+        ttk.Button(left, text="Legend", command=self.toggleLegend).grid(
+            column=0, row=5, sticky=(S, E, W))
+        ttk.Button(left, text="Export PDF", command=self.exportPdf).grid(
+            column=1, row=5, sticky=(S, E, W))
 
-        bdelete = ttk.Button(frm,text="Remove",command=self.removeLine)
-        bdelete.grid(column=0,row=2,sticky=(S,E,W))
+        left.columnconfigure(0, weight=1)
+        left.columnconfigure(1, weight=1)
+        left.rowconfigure(1, weight=1)
 
-        bdeleteAll = ttk.Button(frm,text="Remove All",command=self.removeAll)
-        bdeleteAll.grid(column=1,row=2,sticky=(S,E,W))
+        # --- Right panel: figure, toolbar, readout ---
+        right = ttk.Frame(self)
+        self.add(right)
 
-        baddaxis = ttk.Button(frm,text="Add Axis",command=self.addAxis)
-        baddaxis.grid(column=0,row=4,sticky=(S,E,W))
+        self.fig = Figure(dpi=100)
+        self.canvas = FigureCanvasTkAgg(self.fig, master=right)
+        self.toolbar = NavigationToolbar2Tk(self.canvas, right, pack_toolbar=False)
+        self.toolbar.update()
 
-        bautosize = ttk.Button(frm,text="Auto size",command=self.autoSize)
-        bautosize.grid(column=1,row=4,sticky=(S,E,W))
+        self.readout = Text(right, height=1, font=("Courier", 9),
+                            state=DISABLED, bg='#2b2b2b', fg='#e0e0e0',
+                            wrap=NONE, borderwidth=1, relief="sunken",
+                            insertbackground='white')
+        self.status_var = StringVar(value="")
+        self.status = tkinter.Label(right, textvariable=self.status_var,
+                                    font=("Courier", 9), anchor=W,
+                                    bg='#2b2b2b', fg='#e0e0e0')
 
-        frm.columnconfigure(0,weight=1)
-        frm.rowconfigure(1,weight=1)
+        self.canvas.get_tk_widget().pack(side=TOP, fill=BOTH, expand=True)
+        self.toolbar.pack(side=TOP, fill=X)
+        self.readout.pack(side=TOP, fill=X, padx=2, pady=(2, 0))
+        self.status.pack(side=BOTTOM, fill=X, padx=2)
 
-        self.fig = Figure(dpi=90)
-        self.gridspec = self.fig.add_gridspec(1, 1)
+        # --- State ---
+        self.axes = []
+        self._num_axes = 0
+        self.axis_index = 0
+        self.wave_data = {}
+        self._legend_visible = False
 
-        frame = ttk.Frame(self)
-        self.add(frame)
-        self.canvas = FigureCanvasTkAgg(self.fig, master=frame)# A tk.DrawingArea.
-        toolbar = NavigationToolbar2Tk(self.canvas, frame, pack_toolbar=True)
-        toolbar.update()
+        # Cursor state
+        self.cursor_a_x = None
+        self.cursor_b_x = None
+        self._cursor_a_lines = []
+        self._cursor_b_lines = []
+        self._delta_annotations = []
+        self._dragging = None
+        self._last_mouse_x = None
 
-        self.canvas.mpl_connect(
-            "key_press_event", lambda event: print(f"you pressed {event.key}"))
-        self.canvas.mpl_connect("key_press_event", key_press_handler)
-        toolbar.pack(side=tkinter.BOTTOM, fill=tkinter.X)
-        self.canvas.get_tk_widget().pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=True)
+        # --- Events ---
+        self.canvas.mpl_connect('button_press_event', self._on_press)
+        self.canvas.mpl_connect('button_release_event', self._on_release)
+        self.canvas.mpl_connect('motion_notify_event', self._on_motion)
+        self.canvas.mpl_connect('scroll_event', self._on_scroll)
+        self.canvas.mpl_connect('key_press_event', self._on_key)
 
-        self.waves = dict()
-        self.axes = list()
-        self.index = 0
         self.addAxis()
-        pass
 
-    def show(self,wave):
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
-        if(wave.tag in self.waves):
+    def show(self, wave):
+        if wave.tag in self.wave_data:
             return
 
-        #- Let the wave figure out how to plot on the axis
-        wave.plot(self.axes[self.index])
+        idx = self.axis_index
+        wave.plot(self.axes[idx])
+        self.wave_data[wave.tag] = (wave, idx)
 
-        if(self.index == 0):
-            self.axes[self.index].set_xlabel(wave.xlabel)
+        if idx == 0 and len(self.wave_data) == 1:
+            self.axes[0].set_xlabel(wave.xlabel)
 
-        #- Set Meta info on the wave
-        self.waves[wave.tag] = wave
+        text = "A%d: %s" % (idx, wave.ylabel)
+        self.tree.insert('', 'end', wave.tag, text=text, tags=(wave.tag,))
+        self.tree.tag_configure(wave.tag, foreground=wave.line.get_color())
 
-
-        text = "A%d: " %self.index + wave.ylabel
-
-        self.tree.insert('','end',wave.tag,text=text ,tags=(wave.tag,))
-        self.tree.tag_configure(wave.tag,foreground=wave.line.get_color())
-        self.canvas.draw()
+        self._create_cursor_lines()
+        self.canvas.draw_idle()
 
     def removeAll(self):
-        """Go through all waves in treeview and remove them"""
-        ll = self.tree.get_children()
-        for tag in ll:
-            self.removeTag(tag)
-
-        self.canvas.draw()
-        pass
-
-    def setAxesIndex(self,event):
-        self.index = self.combo.current()
-
-    def addAxis(self):
-        if(len(self.axes) == 0):
-            ax  = self.fig.add_subplot()
-        else:
-            ax  = self.fig.add_subplot(sharex=self.axes[0])
-            ax.xaxis.set_tick_params(labelbottom=False)
-
-        ax.grid()
-        ax.autoscale()
-        self.axes.append(ax)
-        N = len(self.axes)
-        self.index = N-1
-
-        saxes = list()
-        for i in range(0,N):
-            saxes.append("Axes %d" %i)
-
-        self.combo['values'] = saxes
-        self.combo.current(self.index)
-
-        axes = self.fig.get_axes()
-
-        #- Find boundingrect
-        for a in axes:
-            pos = a.get_position()
-
-        width = 0.85
-        height = 0.85
-
-        x = 0.1
-        htext = 0
-        y  = 0.1 + htext
-        axh = height/N
-        for a in axes:
-            pos = [x,y,width,axh - htext]
-            #print(pos)
-            y += axh + htext
-            a.set_position(pos)
-
-        self.canvas.draw()
-        pass
-
-    def autoSize(self):
-        for ax in self.axes:
-            if(ax):
-                ax.relim()
-                ax.autoscale_view(True,True,True)
-        self.canvas.draw()
-
-    def reloadAll(self):
-        ll = self.tree.get_children()
-        for tag in ll:
-            wave = self.waves[tag]
-            wave.reload()
-        self.autoSize()
-        pass
+        for tag in list(self.tree.get_children()):
+            self._remove_tag(tag)
+        self.canvas.draw_idle()
 
     def removeLine(self):
         tag = self.tree.focus()
-        self.removeTag(tag)
-        self.canvas.draw()
-        pass
+        self._remove_tag(tag)
+        self.canvas.draw_idle()
 
-    def removeTag(self,tag):
-        if(tag == ""):
+    def addAxis(self):
+        self._num_axes += 1
+        self._rebuild_axes()
+        self.axis_index = self._num_axes - 1
+        self._update_combo()
+
+    def removeAxis(self):
+        if self._num_axes <= 1:
             return
-        if(not self.tree.exists(tag)):
+        last = self._num_axes - 1
+        tags_to_remove = [t for t, (_, ai) in self.wave_data.items() if ai == last]
+        for t in tags_to_remove:
+            self._remove_tag(t)
+        self._num_axes -= 1
+        self.axis_index = min(self.axis_index, self._num_axes - 1)
+        self._rebuild_axes()
+        self._update_combo()
+
+    def autoSize(self):
+        for ax in self.axes:
+            ax.relim()
+            ax.autoscale_view(True, True, True)
+        self.canvas.draw_idle()
+
+    def reloadAll(self):
+        for tag, (wave, _) in self.wave_data.items():
+            wave.reload()
+        self.autoSize()
+
+    def clearCursors(self):
+        for line in self._cursor_a_lines + self._cursor_b_lines:
+            line.remove()
+        self._cursor_a_lines.clear()
+        self._cursor_b_lines.clear()
+        self._clear_delta_annotations()
+        self.cursor_a_x = None
+        self.cursor_b_x = None
+        self._update_readout()
+        self.canvas.draw_idle()
+
+    def toggleLegend(self):
+        self._legend_visible = not self._legend_visible
+        for ax in self.axes:
+            legend = ax.get_legend()
+            if self._legend_visible:
+                ax.legend(loc='best', fontsize=7, framealpha=0.8)
+            elif legend:
+                legend.remove()
+        self.canvas.draw_idle()
+
+    def exportPdf(self):
+        filename = tkinter.filedialog.asksaveasfilename(
+            defaultextension=".pdf",
+            filetypes=[("PDF files", "*.pdf"), ("All files", "*.*")],
+            initialdir=os.getcwd())
+        if filename:
+            self.fig.savefig(filename, bbox_inches='tight')
+
+    # ------------------------------------------------------------------
+    # Axis management
+    # ------------------------------------------------------------------
+
+    def _rebuild_axes(self):
+        saved_xlim = self.axes[0].get_xlim() if self.axes else None
+        saved_ylims = {i: ax.get_ylim() for i, ax in enumerate(self.axes)}
+
+        self.fig.clear()
+        n = self._num_axes
+
+        if n == 1:
+            self.axes = [self.fig.add_subplot(1, 1, 1)]
+        else:
+            axs = self.fig.subplots(n, 1, sharex=True)
+            self.axes = list(axs)
+            self.fig.subplots_adjust(hspace=0.08)
+
+        for ax in self.axes:
+            ax.grid(True, alpha=0.3)
+            ax.tick_params(axis='both', which='major', labelsize=8)
+        if n > 1:
+            for ax in self.axes[:-1]:
+                ax.tick_params(labelbottom=False)
+
+        for tag, (wave, ax_idx) in list(self.wave_data.items()):
+            ax_idx = min(ax_idx, n - 1)
+            wave.line = None
+            wave.plot(self.axes[ax_idx])
+            self.wave_data[tag] = (wave, ax_idx)
+            if self.tree.exists(tag) and wave.line:
+                self.tree.tag_configure(tag, foreground=wave.line.get_color())
+
+        if saved_xlim and self.axes:
+            self.axes[0].set_xlim(saved_xlim)
+        for i, ax in enumerate(self.axes):
+            if i in saved_ylims:
+                ax.set_ylim(saved_ylims[i])
+
+        self._cursor_a_lines.clear()
+        self._cursor_b_lines.clear()
+        self._delta_annotations.clear()
+        self._create_cursor_lines()
+        self._update_delta_annotations()
+        self.canvas.draw_idle()
+
+    def _update_combo(self):
+        labels = ["Axes %d" % i for i in range(self._num_axes)]
+        self.combo['values'] = labels
+        self.combo.current(self.axis_index)
+
+    def _set_axis_index(self, event):
+        self.axis_index = self.combo.current()
+
+    def _remove_tag(self, tag):
+        if not tag or not self.tree.exists(tag):
             return
         self.tree.delete(tag)
-        if(tag in self.waves):
-            self.waves[tag].deleteLine()
-            del self.waves[tag]
+        if tag in self.wave_data:
+            wave, _ = self.wave_data[tag]
+            if wave.line:
+                wave.line.remove()
+                wave.line = None
+            del self.wave_data[tag]
+
+    # ------------------------------------------------------------------
+    # Cursor system
+    # ------------------------------------------------------------------
+
+    def _create_cursor_lines(self):
+        existing_a = len(self._cursor_a_lines)
+        existing_b = len(self._cursor_b_lines)
+        for i, ax in enumerate(self.axes):
+            if self.cursor_a_x is not None and i >= existing_a:
+                line = ax.axvline(self.cursor_a_x, color=CURSOR_A_COLOR,
+                                  **CURSOR_KWARGS)
+                self._cursor_a_lines.append(line)
+            if self.cursor_b_x is not None and i >= existing_b:
+                line = ax.axvline(self.cursor_b_x, color=CURSOR_B_COLOR,
+                                  **CURSOR_KWARGS)
+                self._cursor_b_lines.append(line)
+
+    def _set_cursor(self, which, x):
+        if which == 'a':
+            self.cursor_a_x = x
+            if not self._cursor_a_lines:
+                for ax in self.axes:
+                    line = ax.axvline(x, color=CURSOR_A_COLOR, **CURSOR_KWARGS)
+                    self._cursor_a_lines.append(line)
+            else:
+                for line in self._cursor_a_lines:
+                    line.set_xdata([x, x])
+        else:
+            self.cursor_b_x = x
+            if not self._cursor_b_lines:
+                for ax in self.axes:
+                    line = ax.axvline(x, color=CURSOR_B_COLOR, **CURSOR_KWARGS)
+                    self._cursor_b_lines.append(line)
+            else:
+                for line in self._cursor_b_lines:
+                    line.set_xdata([x, x])
+        self._update_readout()
+        self.canvas.draw_idle()
+
+    def _near_cursor(self, event, cursor_x):
+        if cursor_x is None or event.inaxes is None:
+            return False
+        disp_cursor, _ = event.inaxes.transData.transform((cursor_x, 0))
+        return abs(event.x - disp_cursor) < DRAG_TOLERANCE_PX
+
+    def _interp_y(self, wave, x):
+        if wave.x is None or x is None:
+            return None
+        try:
+            return float(np.interp(x, np.real(wave.x), np.real(wave.y)))
+        except Exception:
+            return None
+
+    def _get_xunit(self):
+        for wave, _ in self.wave_data.values():
+            if wave.xunit:
+                return wave.xunit
+        return ""
+
+    @staticmethod
+    def _eng(value, unit=""):
+        return EngFormatter(unit=unit)(value)
+
+    def _clear_delta_annotations(self):
+        for ann in self._delta_annotations:
+            ann.remove()
+        self._delta_annotations.clear()
+
+    def _update_delta_annotations(self):
+        self._clear_delta_annotations()
+        if self.cursor_a_x is None or self.cursor_b_x is None:
+            return
+
+        xunit = self._get_xunit()
+        dx = self.cursor_b_x - self.cursor_a_x
+        mid_x = (self.cursor_a_x + self.cursor_b_x) / 2.0
+
+        waves_per_axis = {}
+        for tag, (wave, ax_idx) in self.wave_data.items():
+            waves_per_axis.setdefault(ax_idx, []).append(wave)
+
+        for ax_idx, ax in enumerate(self.axes):
+            text_parts = ["ΔX: %s" % self._eng(dx, xunit)]
+            if dx != 0 and xunit == 's':
+                text_parts[0] += "  (1/ΔX: %s)" % self._eng(1.0 / abs(dx), 'Hz')
+
+            for wave in waves_per_axis.get(ax_idx, []):
+                ya = self._interp_y(wave, self.cursor_a_x)
+                yb = self._interp_y(wave, self.cursor_b_x)
+                if ya is not None and yb is not None:
+                    text_parts.append("Δ%s: %s" % (wave.key, self._eng(yb - ya, wave.yunit)))
+
+            ann = ax.annotate(
+                "\n".join(text_parts),
+                xy=(mid_x, 0.97), xycoords=('data', 'axes fraction'),
+                fontsize=7, fontfamily='monospace',
+                color='#e0e0e0',
+                bbox=dict(boxstyle='round,pad=0.3', fc='#333333', ec='#666666', alpha=0.85),
+                ha='center', va='top')
+            self._delta_annotations.append(ann)
+
+    def _update_readout(self):
+        self.readout.config(state=NORMAL)
+        self.readout.delete('1.0', END)
+
+        if self.cursor_a_x is None and self.cursor_b_x is None:
+            self._clear_delta_annotations()
+            self.readout.config(state=DISABLED, height=1)
+            return
+
+        xunit = self._get_xunit()
+        lines = []
+        parts = []
+        if self.cursor_a_x is not None:
+            parts.append("A: %s" % self._eng(self.cursor_a_x, xunit))
+        if self.cursor_b_x is not None:
+            parts.append("B: %s" % self._eng(self.cursor_b_x, xunit))
+        if self.cursor_a_x is not None and self.cursor_b_x is not None:
+            dx = self.cursor_b_x - self.cursor_a_x
+            parts.append("ΔX: %s" % self._eng(dx, xunit))
+            if dx != 0:
+                if xunit == 's':
+                    parts.append("(1/ΔX: %s)" % self._eng(1.0 / abs(dx), 'Hz'))
+                else:
+                    parts.append("(1/ΔX: %s)" % self._eng(1.0 / abs(dx)))
+        lines.append("  ".join(parts))
+
+        for tag, (wave, _) in self.wave_data.items():
+            yu = wave.yunit
+            parts = ["  %-22s" % wave.key]
+            ya = self._interp_y(wave, self.cursor_a_x)
+            yb = self._interp_y(wave, self.cursor_b_x)
+            if ya is not None:
+                parts.append("A: %-14s" % self._eng(ya, yu))
+            if yb is not None:
+                parts.append("B: %-14s" % self._eng(yb, yu))
+            if ya is not None and yb is not None:
+                parts.append("Δ: %-14s" % self._eng(yb - ya, yu))
+            lines.append("".join(parts))
+
+        self._update_delta_annotations()
+
+        self.readout.insert('1.0', "\n".join(lines))
+        self.readout.config(state=DISABLED, height=min(len(lines), 8))
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    def _on_press(self, event):
+        if self.toolbar.mode != '' or event.inaxes is None:
+            return
+        if event.xdata is None:
+            return
+
+        if self._near_cursor(event, self.cursor_a_x):
+            self._dragging = 'a'
+            return
+        if self._near_cursor(event, self.cursor_b_x):
+            self._dragging = 'b'
+            return
+
+        if event.button == 1:
+            if event.key == 'shift':
+                self._set_cursor('b', event.xdata)
+            else:
+                self._set_cursor('a', event.xdata)
+        elif event.button == 3:
+            self._set_cursor('b', event.xdata)
+
+    def _on_release(self, event):
+        self._dragging = None
+
+    def _on_motion(self, event):
+        if event.inaxes is not None and event.xdata is not None:
+            self._last_mouse_x = event.xdata
+            xu = self._get_xunit()
+            self.status_var.set("x: %s   y: %.6g" % (self._eng(event.xdata, xu),
+                                                       event.ydata))
+        else:
+            self.status_var.set("")
+
+        if self._dragging and event.xdata is not None:
+            self._set_cursor(self._dragging, event.xdata)
+
+    def _on_key(self, event):
+        if event.key == 'a' and event.xdata is not None:
+            self._set_cursor('a', event.xdata)
+        elif event.key == 'b' and event.xdata is not None:
+            self._set_cursor('b', event.xdata)
+
+    def placeCursorA(self):
+        if self._last_mouse_x is not None:
+            self._set_cursor('a', self._last_mouse_x)
+
+    def placeCursorB(self):
+        if self._last_mouse_x is not None:
+            self._set_cursor('b', self._last_mouse_x)
+
+    def _on_scroll(self, event):
+        ax = event.inaxes
+        if ax is None or event.xdata is None:
+            return
+
+        if event.button == 'up':
+            scale = 1.0 / ZOOM_FACTOR
+        elif event.button == 'down':
+            scale = ZOOM_FACTOR
+        else:
+            return
+
+        if event.key == 'shift':
+            # Zoom y-axis
+            ydata = event.ydata
+            ylo, yhi = ax.get_ylim()
+            new_lo = ydata - (ydata - ylo) * scale
+            new_hi = ydata + (yhi - ydata) * scale
+            ax.set_ylim(new_lo, new_hi)
+        else:
+            # Zoom x-axis (affects all shared axes)
+            xdata = event.xdata
+            xlo, xhi = ax.get_xlim()
+            new_lo = xdata - (xdata - xlo) * scale
+            new_hi = xdata + (xhi - xdata) * scale
+            ax.set_xlim(new_lo, new_hi)
+
+        self.canvas.draw_idle()
+
 
 class WaveGraph(ttk.Frame):
 
-    def __init__(self,master=None,**kw):
-        super().__init__(master,width=800,borderwidth=1,relief="raised", **kw)
+    def __init__(self, master=None, **kw):
+        super().__init__(master, width=800, borderwidth=1, relief="raised", **kw)
 
-        self.nb = ttk.Notebook(self,width=800)
-        self.nb.grid(column=0,row=0,sticky=(N,S,E,W))
-        self.columnconfigure(0,weight=1)
-        self.rowconfigure(0,weight=1)
+        self.nb = ttk.Notebook(self, width=800)
+        self.nb.grid(column=0, row=0, sticky=(N, S, E, W))
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure(0, weight=1)
 
         self.index = 0
-        self.current = None
-
         self.addPlot()
 
     def addPlot(self):
         w = WavePlot(self.nb)
-        self.nb.add(w,text=f"Plot {self.index}")
-        self.index +=1
+        self.nb.add(w, text="Plot %d" % self.index)
+        self.index += 1
 
     def reloadPlots(self):
-        tabs = self.nb.tabs()
-        for t in tabs:
-            w = self.nb.nametowidget(t)
-            w.reloadAll()
+        for t in self.nb.tabs():
+            self.nb.nametowidget(t).reloadAll()
 
-    def show(self,wave):
+    def show(self, wave):
         w = self.nb.nametowidget(self.nb.select())
-        if(w is not None):
+        if w is not None:
             w.show(wave)
+
+    def getCurrentPlot(self):
+        tab = self.nb.select()
+        if tab:
+            return self.nb.nametowidget(tab)
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 ]
 description = "Custom IC Creator Simulation Tools"
 readme = "README.md"
-license = "MIT"
+license = {text = "MIT"}
 requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/tests/unittests/test_spec_min_zero.py
+++ b/tests/unittests/test_spec_min_zero.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Test for issue #27: summary must mark values as out of spec when min is 0.
+
+When tran.yaml has min: 0 and max: 100, a value of 104 must be marked out of spec
+(OK() False, markdown() returns styled span), not treated as in-spec because 0 is falsy.
+"""
+
+import unittest
+
+import cicsim as cs
+
+
+class TestSpecMinZero(unittest.TestCase):
+    """Spec with min=0 must still flag values above max as out of spec."""
+
+    def test_ok_false_when_above_max_and_min_is_zero(self):
+        spec = cs.SpecMinMax({
+            "src": ["i_vdd_70"],
+            "name": "Active current at 70 C",
+            "min": 0,
+            "max": 100,
+            "digits": 3,
+            "scale": -1e6,
+            "unit": "µA",
+        })
+        self.assertEqual(spec.min, 0)
+        self.assertEqual(spec.max, 100)
+        # 104 > max → out of spec
+        self.assertFalse(spec.OK(104), "104 > max 100 should be out of spec when min=0")
+
+    def test_ok_true_when_in_range_and_min_is_zero(self):
+        spec = cs.SpecMinMax({
+            "min": 0,
+            "max": 100,
+            "digits": 3,
+            "unit": "µA",
+        })
+        self.assertTrue(spec.OK(50))
+        self.assertTrue(spec.OK(0))
+        self.assertTrue(spec.OK(100))
+
+    def test_markdown_marks_out_of_spec_when_min_is_zero(self):
+        spec = cs.SpecMinMax({
+            "min": 0,
+            "max": 100,
+            "digits": 3,
+            "unit": "µA",
+        })
+        # Value above max must be marked (red or orange span)
+        out = spec.markdown(104)
+        self.assertIn("color:", out, "104 > max should be marked with color when min=0")
+        self.assertIn("104", out)
+
+    def test_markdown_plain_when_in_spec_and_min_is_zero(self):
+        spec = cs.SpecMinMax({
+            "min": 0,
+            "max": 100,
+            "digits": 3,
+            "unit": "µA",
+        })
+        out = spec.markdown(50)
+        self.assertNotIn("color:", out, "50 in [0,100] should not be marked")
+        self.assertIn("50", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Rewrite wave viewer with proper matplotlib subplot layout, draggable measurement cursors (A/B), scroll-wheel zoom, keyboard shortcuts, engineering notation on axes and readout, Export PDF, legend toggle, regex search tooltip, and Help menu
- Fix `pyproject.toml` license field for Python 3.8 compatibility

## Test plan
- [x] Open a raw simulation file and verify waveforms display correctly
- [x] Press `a` / `b` to place cursors, verify delta readout on plot and in readout panel
- [x] Test scroll-wheel zoom (x-axis) and shift+scroll (y-axis)
- [x] Test legend toggle (`l`), auto-scale (`f`), reload (`r`)
- [x] Export PDF and verify output
- [x] Hover over search bar and verify regex tooltip appears
- [x] Verify `pip install` works on Python 3.8

Made with [Cursor](https://cursor.com)